### PR TITLE
Setup Version Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Then navigate the command prompt to your local plugin project files (where thund
 
 You can bundle the plugin for local testing by running `tcli build` (make sure to build in Visual Studio first!)
 
+**NEW FEATURE: This bundle process also is configured to AUTOMATICALLY happen whenever you build the project with the "Release" configuration. (Dropdown at the top in Visual Studio)**
+
 You can then import the zip file created in the `build` folder as a local mod into your mod manager.
 
 Once you're ready to publish, follow the steps [here](https://github.com/thunderstore-io/thunderstore-cli/wiki#authentication) to setup a service account and get the token. (DO NOT SHARE THE TOKEN, EVER.)
@@ -149,11 +151,10 @@ Congrats! 🎉 After a few minutes people can start downloading your plugin from
 
 ## Creating a new version
 
-1) Update thunderstore.toml with the new version number.
-2) Update your `.csproj` file with the new version number.
-3) Add an entry in [versions.json](versions.json) for the new version number.
-4) Build and bundle the plugin.
-5) After testing locally, (Change MoCore's settings to disable the version checker if needed) commit & push to GitHub then publish using `tcli publish --token ReplaceWithTheToken`
+1) Add an entry in [versions.json](versions.json) for the new version number (format it like this: `MAJOR.MINOR.PATCH` )
+2) Commit your code, then tag the commit with the version number formatted like this `vMAJOR.MINOR.PATCH` (ex. `v1.0.0`)
+3) Build the plugin using the `Release` configuration to automatically bundle it
+4) After testing locally, (Change MoCore's settings to disable the version checker if needed) push to GitHub & then publish to Thunderstore using `tcli publish --token ReplaceWithTheToken`
 
 ## When The Game Updates
 

--- a/TemplatePlugin/TemplatePlugin.csproj
+++ b/TemplatePlugin/TemplatePlugin.csproj
@@ -5,15 +5,29 @@
     <AssemblyName>com.mosadie.templateplugin</AssemblyName>
     <Product>TemplatePlugin</Product>
     <Description>A Template Plugin, this description should be changed!</Description>
-    <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+
+    <!-- MinVer settings, by default looking for a tag starting with v (ex v1.0.0)-->
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
+
+  <!-- Taken from Xilophor/Lethal-Company-Mod-Templates to set Mod Version correctly in *all* locations -->
+  <Target Name="SetModVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">
+    <PropertyGroup>
+      <PlainVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</PlainVersion>
+      <BepInExPluginVersion>$(PlainVersion)</BepInExPluginVersion>
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="UnityEngine.Modules" Version="2021.3.32" IncludeAssets="compile" />
   </ItemGroup>
@@ -22,15 +36,23 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 
+  <!-- Reference to Slipstream's Game Code -->
   <ItemGroup>
     <Reference Include="GameAssembly">
       <HintPath>lib/Assembly-CSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
 
+  <!-- Reference to MoCore, can remove if you don't want to use MoCore -->
   <ItemGroup>
     <Reference Include="MoCore">
       <HintPath>lib/com.mosadie.mocore.dll</HintPath>
     </Reference>
   </ItemGroup>
+
+  <!-- Automatically attempts to package plugin for use in a manager, ONLY WHEN USING "Release" CONFIGURATION-->
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release'">
+    <Message Text="Packaging using tcli..." />
+    <Exec Command="tcli build --package-version $(MinVerMajor).$(MinVerMinor).$(MinVerPatch)" WorkingDirectory=".." />
+  </Target>
 </Project>

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -4,7 +4,6 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "MoSadie"
 name = "TemplatePlugin"
-versionNumber = "1.0.0"
 description = "A Template Plugin, this description should be changed!"
 websiteUrl = "https://github.com/MoSadie/Slipstream-Template-Plugin"
 containsNsfwContent = false


### PR DESCRIPTION
No longer need to manually update version numbers in multiple files.  Generates the version number based on the tag of the latest commit.

If commit is tagged (ex `v1.0.0`) that will be the version until another commit is made, then it will increase the last digit by one.